### PR TITLE
Method to format the matrix when logging

### DIFF
--- a/matrix.js
+++ b/matrix.js
@@ -209,3 +209,11 @@ Matrix.prototype.visualize = function(idSelector) {
     table.appendChild(row);
   });
 }
+
+Matrix.prototype.pprint = function(){ //"pretty print" the matrix
+  let fstring = '['; 
+  for (let i=0;i<this.matrix.length;i++){
+    fstring +=  (i!=0?' ':'') + ` [${this.matrix[i].map(x=>' ' + x.toString() + ' ')}],\n`;
+  }
+  console.log(fstring.substring(0,fstring.length-2) + ' ]');
+}


### PR DESCRIPTION
The visualize method is great, but when I'm trying to debug creating an element like that can be annoying. I added a `pprint` method that logs the Matrix to the console much more nicely: 

```
[ [ 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
  [ 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ],
  [ 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 , 0 ] ] 
```

This way, you can easily see the dimensions.